### PR TITLE
save the edep-sim vertexID as interaction ID

### DIFF
--- a/python/larnd2supera/driver.py
+++ b/python/larnd2supera/driver.py
@@ -480,7 +480,7 @@ class SuperaDriver(edep2supera.edep2supera.SuperaDriver):
         # but Supera/LArCV want a regular int, hence the type casting
         # TODO Is there a cleaner way to handle this?
         p.id             = int(trajectory['event_id'])
-        #p.interaction_id = trajectory['interactionID']
+        p.interaction_id = int(trajectory['vertex_id'])   # this is the VertexID assigned at edep-sim stage
         p.trackid        = int(trajectory['traj_id'])
         p.pdg            = int(trajectory['pdg_id'])
         p.px = trajectory['pxyz_start'][0] 


### PR DESCRIPTION
This allows us to use the interaction ID downstream to determine which GENIE file(s) we should be digging around in if we want to find the original GENIE events.  

n.b.: for this to make it all the way through the pipeline intact, there are a couple other things that are also necessary:

- the YAML configuration in use needs to set `RewriteInteractionID:  False` under `LabelConfig`
- pull requests to SuperaAtomic (https://github.com/DeepLearnPhysics/SuperaAtomic/pull/17) and larcv2 (https://github.com/DeepLearnPhysics/larcv2/pull/43) will need to be merged