### PR TITLE
Trigger propagation & interaction ID storing

### DIFF
--- a/python/larnd2supera/config_data/2x2.yaml
+++ b/python/larnd2supera/config_data/2x2.yaml
@@ -34,5 +34,6 @@ LabelConfig:
     StoreLEScatter:   True
     SemanticPriority: [1,0,2,3,4]
     EnergyDepositThreshold: 0.0
+    RewriteInteractionID:  False
     #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
     #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]

--- a/python/larnd2supera/config_data/2x2_PR4.1.yaml
+++ b/python/larnd2supera/config_data/2x2_PR4.1.yaml
@@ -1,0 +1,39 @@
+# ===============
+# 2x2.yaml
+# ===============
+
+LogLevel:        INFO
+EventSeparator:  'event_id'
+ActiveDetectors: ["TPCActive_shape"]
+MaxSegmentSize:  0.03
+PropertyKeyword: '2x2_MR4'
+TileLayout: ''
+DetectorProperties: ''
+ParserRunConfig:
+    event_separator: 'event_id'
+ElectronEnergyThreshold: 5
+
+BBoxAlgorithm: BBoxInteraction
+BBoxConfig:
+    LogLevel:   WARNING
+    Seed:       -1
+    BBoxSize:   [141.888,127.6992,141.888]
+    BBoxTop:    [70.944,-204.1504,1370.944]  
+    BBoxBottom: [-70.944,-331.8496,1229.056] 
+    VoxelSize:  [0.4434,0.4434,0.4434]
+    #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
+    #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]
+
+LabelAlgorithm: LArTPCMLReco3D
+LabelConfig:
+    LogLevel: WARNING
+    DeltaSize:     3
+    ComptonSize:  10
+    LEScatterSize: 2
+    TouchDistance: 1
+    StoreLEScatter:   True
+    SemanticPriority: [1,0,2,3,4]
+    EnergyDepositThreshold: 0.0
+    RewriteInteractionID:  False
+    #WorldBoundMax: [-1.e20,-1.e20,-1.e20]
+    #WorldBoundMin: [ 1.e20, 1.e20, 1.e20]

--- a/python/larnd2supera/utils.py
+++ b/python/larnd2supera/utils.py
@@ -183,8 +183,9 @@ def run_supera(out_file='larcv.root',
 
         trigger = writer.get_data("trigger", "base")
         trigger.id(int(input_data.event_id))  # fixme: this will need to be different for real data?
-        trigger.time_s(int(input_data.t0))
-        trigger.time_ns(int(1e9 * (input_data.t0 - trigger.time_s())))
+        # input_data.t0 is in microseconds
+        trigger.time_s(int(input_data.t0 / 1e6))
+        trigger.time_ns(int(1e3 * (input_data.t0 % 1e6)))
 
         # TODO fill the run ID 
         writer.set_id(0,0,int(input_data.event_id))


### PR DESCRIPTION
* fills a `Trigger` product used to store info about readouts from the DAQ
* add config option that takes interaction ID directly from edep-sim upstream